### PR TITLE
Exclude groovy from the http-builder dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     compile 'org.apache.ivy:ivy:2.2.0'
     compile 'commons-cli:commons-cli:1.2' // should be part of groovy, but not available when running for some reason
     testCompile 'junit:junit:4.10'
-    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.5.2'
+    compile ('org.codehaus.groovy.modules.http-builder:http-builder:0.5.2') {
+        excludes 'groovy'
+    }
 }
 
 task createSourceDirs(description : 'Create empty source directories for all defined sourceSets') << {


### PR DESCRIPTION
Http Builder was updated and it appears it's causing a conflict with groovy
